### PR TITLE
Replace `arch` by `uname -r` since is more portable

### DIFF
--- a/bin/get_haskell_stack
+++ b/bin/get_haskell_stack
@@ -60,7 +60,7 @@ post_install_separator() {
 
 # determines the the CPU's instruction set
 get_isa() {
-  if arch | grep -q arm ; then
+  if uname -m | grep -q arm ; then
     echo arm
   else
     echo x86


### PR DESCRIPTION
`arch` command is not available on Arch linux, from what I found here https://github.com/google/fscrypt/issues/92#issuecomment-365712796 it's not compiled by default in coreutils, it need to be enabled at configure time. `uname -m` is more portable and do the same thing.