### PR TITLE
Add .gitignore and ignore stack/stack

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+stack/stack


### PR DESCRIPTION
After installing asdf-haskell and installing one version I noticed the plugin's git state was dirty.

There was only one file: the local stack installation.